### PR TITLE
Using run-loop targeted cancel previous selector call

### DIFF
--- a/WebServiceManager/RZWebServiceManager.m
+++ b/WebServiceManager/RZWebServiceManager.m
@@ -27,6 +27,15 @@
 @synthesize defaultHost = _defaultHost;
 @synthesize apiSpecificHosts = _apiSpecificHosts;
 
+-(id)init{
+    if (self = [super init]){
+        self.requests = [[NSOperationQueue alloc] init];
+        [self.requests setName:@"RZWebServiceManagerQueue"];
+        [self.requests setMaxConcurrentOperationCount:1];
+    }
+    return self;
+}
+
 -(id) initWithCallsPath:(NSString*)callsPath
 {    
     NSDictionary* calls = [NSDictionary dictionaryWithContentsOfFile:callsPath];
@@ -42,6 +51,10 @@
     if (self) {
         self.apiCalls = apiCalls;
         self.apiSpecificHosts = [NSMutableDictionary dictionary];
+        
+        self.requests = [[NSOperationQueue alloc] init];
+        [self.requests setName:@"RZWebServiceManagerQueue"];
+        [self.requests setMaxConcurrentOperationCount:1];
     }
     
     return self;


### PR DESCRIPTION
Using a timer was preventing the runloop from returning from runInMode: sometimes, even after invalidating the timer, which kept the operation queue locked on one operation. Keeping track of the thread for the new runloop and canceling the delayed selector is working as expected.
