### PR TITLE
Default cache and docs directory as class methods

### DIFF
--- a/WebServiceManager/RZFileManager.h
+++ b/WebServiceManager/RZFileManager.h
@@ -33,6 +33,10 @@ typedef void (^RZFileManagerUploadCompletionBlock)(BOOL success, NSURL* uploaded
 // Shared Instance Method
 + (RZFileManager*)defaultManager;
 
+// Class methods for docs/cache directory
++ (NSURL*)defaultDocumentsDirectoryURL;
++ (NSURL*)defaultDownloadCacheURL;
+
 // Download File Request Methods
 - (RZWebServiceRequest*)downloadFileFromURL:(NSURL*)remoteURL withProgressDelegate:(id<RZFileProgressDelegate>)progressDelegate completion:(RZFileManagerDownloadCompletionBlock)completionBlock;
 - (RZWebServiceRequest*)downloadFileFromURL:(NSURL*)remoteURL withProgressDelegate:(id<RZFileProgressDelegate>)progressDelegate enqueue:(BOOL)enqueue completion:(RZFileManagerDownloadCompletionBlock)completionBlock;
@@ -75,7 +79,7 @@ typedef void (^RZFileManagerUploadCompletionBlock)(BOOL success, NSURL* uploaded
 - (void)deleteFileFromCacheWithURL:(NSURL *)localURL;
 
 - (void)setProgress:(float)progress withRequest:(RZWebServiceRequest *)request;
-- (NSURL *)defaultDocumentsDirectoryURL; 
+
 
 - (NSSet*)requestsWithDownloadURL:(NSURL*)downloadURL;
 

--- a/WebServiceManager/RZFileManager.m
+++ b/WebServiceManager/RZFileManager.m
@@ -16,8 +16,6 @@
 @property (strong, nonatomic, readonly) NSMutableSet *downloadRequests;
 @property (strong, nonatomic, readonly) NSMutableSet *uploadRequests;
 
-- (NSURL*)defaultDownloadCacheURL;
-
 - (NSSet*)requestsWithDownloadURL:(NSURL*)downloadURL;
 - (NSSet*)requestsWithUploadURL:(NSURL*)uploadURL;
 - (NSSet*)requestsWithUploadFileURL:(NSURL*)uploadFileURL;
@@ -50,6 +48,63 @@ NSString * const kProgressDelegateKey = @"progressDelegateKey";
     
     return s_RZFileManager;
 }
+
+
++ (NSURL*)defaultDownloadCacheURL
+{
+    NSArray* cachePathsArray = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString* cachePath = [cachePathsArray lastObject];
+    
+    NSURL *cacheURL = nil;
+    
+    if (cachePath)
+    {
+        NSError* error = nil;
+        cacheURL = [NSURL fileURLWithPath:cachePath isDirectory:YES];
+        NSString* fullPath = [cachePath stringByAppendingPathComponent:@"DownloadCache"];
+        if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath])
+        {
+            [[NSFileManager defaultManager] createDirectoryAtPath:fullPath
+                                      withIntermediateDirectories:NO
+                                                       attributes:nil
+                                                            error:&error];
+            if (error != nil)
+                NSLog(@"Error:%@:",error);
+        }
+        cacheURL = [NSURL fileURLWithPath:fullPath];
+    }
+    
+    return cacheURL;
+}
+
++ (NSURL *)defaultDocumentsDirectoryURL {
+    NSArray* cachePathsArray = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString* cachePath = [cachePathsArray lastObject];
+    
+    NSURL *cacheURL = nil;
+    
+    if (cachePath)
+    {
+        NSError* error = nil;
+        cacheURL = [NSURL fileURLWithPath:cachePath isDirectory:YES];
+        NSString* fullPath = [cachePath stringByAppendingPathComponent:@"DownloadCache"];
+        if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath])
+        {
+            [[NSFileManager defaultManager] createDirectoryAtPath:fullPath
+                                      withIntermediateDirectories:NO
+                                                       attributes:nil
+                                                            error:&error];
+            if (error != nil) {
+                NSLog(@"Error:%@:",error);
+            }
+        }
+        cacheURL = [NSURL fileURLWithPath:fullPath];
+    }
+    
+    return cacheURL;
+    
+}
+
 
 - (id)init
 {
@@ -315,7 +370,7 @@ NSString * const kProgressDelegateKey = @"progressDelegateKey";
 {    
     if (_cacheSchema == nil) {
         _cacheSchema = [[RZFileCacheSchema alloc] init];
-        _cacheSchema.downloadCacheDirectory = [self defaultDownloadCacheURL];
+        _cacheSchema.downloadCacheDirectory = [RZFileManager defaultDownloadCacheURL];
     }
     
     return _cacheSchema;
@@ -363,60 +418,6 @@ NSString * const kProgressDelegateKey = @"progressDelegateKey";
 #pragma mark - Private Methods
 
 
-
-- (NSURL*)defaultDownloadCacheURL
-{
-    NSArray* cachePathsArray = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString* cachePath = [cachePathsArray lastObject];
-    
-    NSURL *cacheURL = nil;
-    
-    if (cachePath)
-    {
-        NSError* error = nil;
-        cacheURL = [NSURL fileURLWithPath:cachePath isDirectory:YES];
-        NSString* fullPath = [cachePath stringByAppendingPathComponent:@"DownloadCache"];
-        if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath])
-        {
-            [[NSFileManager defaultManager] createDirectoryAtPath:fullPath
-                                      withIntermediateDirectories:NO
-                                                       attributes:nil
-                                                            error:&error];
-            if (error != nil)
-                NSLog(@"Error:%@:",error);
-        }
-        cacheURL = [NSURL fileURLWithPath:fullPath];
-    }
-    
-    return cacheURL;
-}
-- (NSURL *)defaultDocumentsDirectoryURL {
-    NSArray* cachePathsArray = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString* cachePath = [cachePathsArray lastObject];
-    
-    NSURL *cacheURL = nil;
-    
-    if (cachePath)
-    {
-        NSError* error = nil;
-        cacheURL = [NSURL fileURLWithPath:cachePath isDirectory:YES];
-        NSString* fullPath = [cachePath stringByAppendingPathComponent:@"DownloadCache"];
-        if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath])
-        {
-            [[NSFileManager defaultManager] createDirectoryAtPath:fullPath
-                                      withIntermediateDirectories:NO
-                                                       attributes:nil
-                                                            error:&error];
-            if (error != nil) {
-                NSLog(@"Error:%@:",error);
-            }
-        }
-        cacheURL = [NSURL fileURLWithPath:fullPath];
-    }
-    
-    return cacheURL;
-
-}
 
 #pragma mark - Filtered Request Set Methods
 


### PR DESCRIPTION
Did this in order to facilitate usage of these methods without allocation of the actual file manager (for custom cache schema, etc). The default directory methods are not dependent on instance variables or self, so they are safe as class methods.
