### PR TITLE
Option to bypass URL cache

### DIFF
--- a/WebServiceManager/RZFileManager.m
+++ b/WebServiceManager/RZFileManager.m
@@ -200,6 +200,7 @@ NSString* const RZFileManagerFileUploadCompletedNotification = @"RZFileManagerFi
     [self putObject:progressDelegate inRequest:request atKey:kProgressDelegateKey];
     [self addBlock:completionBlock toRequest:request atKey:kCompletionBlockKey];
     request.targetFileURL = cacheURL;
+    request.shouldCacheResponse = self.shouldCacheDownloads;
     [request addProgressObserver:self];
     
     [self.downloadRequests addObject:request];

--- a/WebServiceManager/RZWebServiceRequest.h
+++ b/WebServiceManager/RZWebServiceRequest.h
@@ -168,6 +168,9 @@ expectedResultType:(NSString *)expectedResultType
 @property (strong, readonly, nonatomic) NSDictionary* responseHeaders;
 @property (assign, readonly, nonatomic) NSInteger statusCode;
 
+// Set to NO to prevent caching URL response. Recommended for large file downloads. Default is YES
+@property (assign, nonatomic) BOOL shouldCacheResponse;
+
 @property (assign, nonatomic) BOOL ignoreCertificateValidity;
 
 // Note: These pre/post process blocks are not used at the moment.

--- a/WebServiceManager/RZWebServiceRequest.m
+++ b/WebServiceManager/RZWebServiceRequest.m
@@ -267,6 +267,8 @@ expectedResultType:(NSString *)expectedResultType
         self.expectedResultType = expectedResultType;
         self.bodyType = bodyType;
         self.copyToTargetAtomically = NO;
+        
+        self.shouldCacheResponse = YES;
 
         self.parameterMode = RZWebserviceRequestParameterModeDefault;
         self.parameters = [parameters convertToURLEncodedParameters];
@@ -1124,6 +1126,11 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
         
         self.done = YES;
     }
+}
+
+- (NSCachedURLResponse*)connection:(NSURLConnection *)connection willCacheResponse:(NSCachedURLResponse *)cachedResponse
+{
+    return self.shouldCacheResponse ? cachedResponse : nil;
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response


### PR DESCRIPTION
This is an optimization for downloading files, mostly. The default URL cache memory usage will steadily build up as HTTP requests are made. For large files, it builds up pretty quickly and doesn't deflate consistently. URL caching is pretty redundant for downloding files, since the files are typically saved to disk and never re-downloaded with a new request, thereby making the URL caching pointless.

Profiling shows a significant difference in live memory usage for downloading hi-res images.

Just as a note, I was implementing this in RZWebserviceRequest, and when that was done I noticed there was already a flag for it in RZFileManager, not hooked up to anything, so I just passed the flag along to RZFileManager's requests.
