### PR TITLE
Use objectForKey methods on dictionary in keychain

### DIFF
--- a/WebServiceManager/RZWebServiceKeychain.m
+++ b/WebServiceManager/RZWebServiceKeychain.m
@@ -65,7 +65,7 @@
     
     if ([serviceObj isKindOfClass:[NSDictionary class]]) {
         serviceObj = [[NSMutableDictionary alloc] initWithDictionary:serviceObj copyItems:NO];
-        [serviceObj setValue:value forKey:key];
+        [serviceObj setObject:value forKey:key];
     }
     
     [self save:service data:serviceObj];
@@ -91,7 +91,7 @@
     
     id serviceObj = [self load:service];
     if ([serviceObj isKindOfClass:[NSDictionary class]]) {
-        val = [serviceObj valueForKey:key];
+        val = [serviceObj objectForKey:key];
     }
     
     return val;


### PR DESCRIPTION
@joe-goullaud Small change. No need to use KVC methods on dictionary in keychain.
