### PR TITLE
Changed constant name so it doesn't conflict with Google Analytics.

### DIFF
--- a/WebServiceManager/RZWebServiceManager.m
+++ b/WebServiceManager/RZWebServiceManager.m
@@ -108,7 +108,7 @@ NSString* const kRZWebserviceCachedCertFingerprints = @"CachedCertFingerprints";
 {
     if (_defaultRequestTimeoutInterval <= 0)
     {
-        _defaultRequestTimeoutInterval = kRZDefaultTimeout;
+        _defaultRequestTimeoutInterval = kRZWebServiceRequestDefaultTimeout;
     }
     return _defaultRequestTimeoutInterval;
 }

--- a/WebServiceManager/RZWebServiceRequest.h
+++ b/WebServiceManager/RZWebServiceRequest.h
@@ -15,7 +15,7 @@ extern NSString* const kFailureHandlerKey;
 extern NSString* const kSuccessHandlerKey;
 extern NSString* const kTimeoutKey;
 
-extern NSTimeInterval const kRZDefaultTimeout;
+extern NSTimeInterval const kRZWebServiceRequestDefaultTimeout;
 
 @class RZWebServiceRequest;
 @class RZWebServiceManager;

--- a/WebServiceManager/RZWebServiceRequest.m
+++ b/WebServiceManager/RZWebServiceRequest.m
@@ -26,7 +26,7 @@ NSString *const kFailureHandlerKey = @"FailureHandler";
 NSString *const kSuccessHandlerKey = @"SuccessHandler";
 NSString *const kTimeoutKey = @"Timeout";
 
-NSTimeInterval const kRZDefaultTimeout = 60;
+NSTimeInterval const kRZWebServiceRequestDefaultTimeout = 60;
 
 @interface RZWebServiceRequest()
 
@@ -725,7 +725,7 @@ expectedResultType:(NSString *)expectedResultType
         
         // setup our timeout callback. 
         if(self.timeoutInterval <= 0)
-            self.timeoutInterval = kRZDefaultTimeout;
+            self.timeoutInterval = kRZWebServiceRequestDefaultTimeout;
         [self scheduleTimeout];
                 
         while (!self.done && !self.isCancelled) {


### PR DESCRIPTION
@joe-goullaud kDefaultTimeout conflicted with a constant Google Analytics use in their library.
