### PR TITLE
Removing set to cacheURL without ever reading.

### DIFF
--- a/WebServiceManager/RZFileManager.m
+++ b/WebServiceManager/RZFileManager.m
@@ -82,7 +82,6 @@ NSString* const RZFileManagerFileUploadCompletedNotification = @"RZFileManagerFi
     if (cachePath)
     {
         NSError* error = nil;
-        cacheURL = [NSURL fileURLWithPath:cachePath isDirectory:YES];
         NSString* fullPath = [cachePath stringByAppendingPathComponent:@"DownloadCache"];
         if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath])
         {
@@ -109,7 +108,6 @@ NSString* const RZFileManagerFileUploadCompletedNotification = @"RZFileManagerFi
     if (cachePath)
     {
         NSError* error = nil;
-        cacheURL = [NSURL fileURLWithPath:cachePath isDirectory:YES];
         NSString* fullPath = [cachePath stringByAppendingPathComponent:@"DownloadCache"];
         if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath])
         {


### PR DESCRIPTION
@ndonald2 @smbarne @nbonatsakis 

Can one of you guys merge this in.  Just removing an analyzer warning.  We set the cache URL right after the method.  Here is the full method if it makes it easier to read than checking it out.

```
+ (NSURL *)defaultDocumentsDirectoryURL
{
    NSArray* cachePathsArray = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
    NSString* cachePath = [cachePathsArray lastObject];

    NSURL *cacheURL = nil;

    if (cachePath)
    {
        NSError* error = nil;
        NSString* fullPath = [cachePath stringByAppendingPathComponent:@"DownloadCache"];
        if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath])
        {
            [[NSFileManager defaultManager] createDirectoryAtPath:fullPath
                                      withIntermediateDirectories:NO
                                                       attributes:nil
                                                            error:&error];
            if (error != nil) {
                NSLog(@"Error:%@:",error);
            }
        }
        cacheURL = [NSURL fileURLWithPath:fullPath];
    }

    return cacheURL;

}
```
