### PR TITLE
Fix flattenArray parameter being ignored.

### DIFF
--- a/WebServiceManager/RZWebService_NSURL.m
+++ b/WebServiceManager/RZWebService_NSURL.m
@@ -118,7 +118,7 @@ NSString * const kRZWebServiceRequestDefaultQueryParameterArrayDelimiter = @"+";
 
 - (NSURL *)URLByAddingParameters:(NSArray *)parameters arrayDelimiter:(NSString *)arrayDelimiter flattenArray:(BOOL)flattenArray
 {    
-    NSString *parameterString = [NSURL URLQueryStringFromParameters:parameters arrayDelimiter:arrayDelimiter flattenArray:NO];
+    NSString *parameterString = [NSURL URLQueryStringFromParameters:parameters arrayDelimiter:arrayDelimiter flattenArray:flattenArray];
     
     NSMutableString *urlString = [NSMutableString stringWithString:[self absoluteString]];
     


### PR DESCRIPTION
Looks like the flattenArray parameter being passed in was being ignored on this NSURL category method.
